### PR TITLE
Fix update of initialized widgets when variant changes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ quote = "1.0.7"
 syn = "1.0.35"
 
 [dev-dependencies]
-druid = "0.6.0"
+druid = "0.7.0"

--- a/examples/login.rs
+++ b/examples/login.rs
@@ -43,7 +43,7 @@ fn ui() -> impl Widget<AppState> {
 
 fn login_ui() -> impl Widget<LoginState> {
     fn login(ctx: &mut EventCtx, state: &mut LoginState, _: &Env) {
-        ctx.submit_command(LOGIN.with(MainState::from(state.clone())), None)
+        ctx.submit_command(LOGIN.with(MainState::from(state.clone())))
     }
 
     Flex::row()


### PR DESCRIPTION
Closes #8 

Note that `druid-enums` now requires Druid 0.7