### PR TITLE
Fix screen getting stuck after #9 fix

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,13 +123,10 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         let (data_pattern, data_values) = data_of(&variant, "");
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
-                ctx.children_changed();
                 match &mut self.#builder_name {
-                    Some(widget) => match widget.is_initialized() {
-                        true => { 
-                            widget.update(ctx, #data_values, env);
-                        },
-                        false => (),
+                     Some(widget) => match widget.is_initialized() {
+                        true => widget.update(ctx, #data_values, env),
+                        false => ctx.children_changed(),
                     },
                     None => (),
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         let (data_pattern, data_values) = data_of(&variant, "");
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
-                ctx.request_paint();
+                ctx.request_layout();
                 match &mut self.#builder_name {
                     Some(widget) => match widget.is_initialized() {
                         true => widget.update(ctx, #data_values, env),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,11 +123,11 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         let (data_pattern, data_values) = data_of(&variant, "");
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
+                ctx.children_changed();
                 match &mut self.#builder_name {
                     Some(widget) => match widget.is_initialized() {
                         true => { 
                             widget.update(ctx, #data_values, env);
-                            ctx.request_paint();
                         },
                         false => (),
                     },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
                 match &mut self.#builder_name {
+                    ctx.request_paint();
                      Some(widget) => match widget.is_initialized() {
                         true => widget.update(ctx, #data_values, env),
                         false => ctx.children_changed(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,7 +123,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         let (data_pattern, data_values) = data_of(&variant, "");
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
-                ctx.children_changed();
+                ctx.request_paint();
                 match &mut self.#builder_name {
                     Some(widget) => match widget.is_initialized() {
                         true => widget.update(ctx, #data_values, env),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,10 +123,11 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         let (data_pattern, data_values) = data_of(&variant, "");
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
+                ctx.children_changed();
                 match &mut self.#builder_name {
                     Some(widget) => match widget.is_initialized() {
                         true => widget.update(ctx, #data_values, env),
-                        false => ctx.children_changed(),
+                        false => (),
                     },
                     None => (),
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,10 +123,12 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         let (data_pattern, data_values) = data_of(&variant, "");
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
-                ctx.request_layout();
                 match &mut self.#builder_name {
                     Some(widget) => match widget.is_initialized() {
-                        true => widget.update(ctx, #data_values, env),
+                        true => { 
+                            widget.update(ctx, #data_values, env);
+                            ctx.request_paint();
+                        },
                         false => (),
                     },
                     None => (),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,8 +123,8 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         let (data_pattern, data_values) = data_of(&variant, "");
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
+                ctx.request_paint();
                 match &mut self.#builder_name {
-                    ctx.request_paint();
                      Some(widget) => match widget.is_initialized() {
                         true => widget.update(ctx, #data_values, env),
                         false => ctx.children_changed(),


### PR DESCRIPTION
As mentioned in https://github.com/Finnerale/druid-enums/issues/8#issuecomment-801101934, the #9 fix made the screen freeze when returning to an older state with the same data due to the missing `children_changed` call.