### PR TITLE
Update matcher's internal discriminant during widget update

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@ pub fn derive(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         let (data_pattern, data_values) = data_of(&variant, "");
         quote! {
             (_, #enum_name::#variant_name #data_pattern) => {
+                self.discriminant_ = Some(::std::mem::discriminant(data));
                 ctx.request_paint();
                 match &mut self.#builder_name {
                      Some(widget) => match widget.is_initialized() {


### PR DESCRIPTION
Hi!
I ran into problems with druid-enums when switching between variants more than once. A simple example can be found in https://github.com/bastikr/druid-enums/tree/discriminant-fail-example (in the example directory). It seems to me that the matcher's discriminant is not updated correctly, i.e. it is only updated during lifecycle calls which are not always happening when data changes. This pull request changes this behavior to also adapt the discriminant in the matcher's update() method. This fixes my problems so far - however, I'm not really familiar with druids internals so I might be missing something here.